### PR TITLE
Fix animation when closing PageReveal.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,8 +73,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
               slideUpdateStream: slideUpdateStream,
               vsync: this,
             );
-
-            nextPageIndex = activeIndex;
           }
 
           animatedPageDragger.run();
@@ -85,8 +83,9 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         }
 
         else if (event.updateType == UpdateType.doneAnimating){
-          activeIndex = nextPageIndex;
-
+          if (animatedPageDragger?.transitionGoal == TransitionGoal.open) {
+            activeIndex = nextPageIndex;
+          }
           slideDirection = SlideDirection.none;
           slidePercent = 0.0;
 


### PR DESCRIPTION
The PageReveal closes immediately when the page was not changed (slidePercent <= 0.5). This commit fixes the animation of PageReveal by changing the page after the main animation was finished.
The effect can be easily observed when the value of PERCENT_PER_MILLISECOND is changed to e.g. 0.001.